### PR TITLE
feature: 회원 가입 검증 추가 및 수정

### DIFF
--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/user/UserController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/user/UserController.java
@@ -1,7 +1,7 @@
 package grepp.NBE5_6_2_Team03.api.controller.user;
 
 import grepp.NBE5_6_2_Team03.api.controller.user.dto.request.UserSignUpRequest;
-import grepp.NBE5_6_2_Team03.api.controller.user.service.UserService;
+import grepp.NBE5_6_2_Team03.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/user/dto/request/UserSignUpRequest.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/user/dto/request/UserSignUpRequest.java
@@ -1,6 +1,8 @@
 package grepp.NBE5_6_2_Team03.api.controller.user.dto.request;
 
 import grepp.NBE5_6_2_Team03.domain.user.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Setter;
 
@@ -9,9 +11,32 @@ import static grepp.NBE5_6_2_Team03.domain.user.Role.*;
 @Setter
 public class UserSignUpRequest {
 
+    @Pattern(
+            regexp = "^[A-Za-z0-9]+@[A-Za-z0-9]+\\.com$",
+            message = "올바른 이메일 형식이어야 합니다."
+    )
+    @NotBlank(message = "이메일은 빈 값을 허용 하지 않습니다.")
     private String email;
+
+    @Pattern(
+            regexp = "^(?=(?:[^!@#$%^&*()]*[!@#$%^&*()]){2,})[A-Za-z0-9!@#$%^&*()]{8,15}$",
+            message = "비밀번호는 최소 8자 ~ 15자이며 특수문자를 2개 이상 포함해야 합니다."
+    )
+    @NotBlank(message = "비밀번호는 빈 값을 허용 하지 않습니다.")
     private String password;
+
+    @Pattern(
+            regexp = "^[A-Za-z가-힣0-9]{2,10}$",
+            message = "회원의 이름은 한글과 영어 문자만 가능하며 최대 10자리 입니다."
+    )
+    @NotBlank(message = "이름은 빈 값을 허용 하지 않습니다.")
     private String name;
+
+    @Pattern(
+            regexp = "^01[016789]-\\d{3,4}-\\d{4}$",
+            message = "휴대폰 번호는 010-1234-5678 형식으로 입력해주세요."
+    )
+    @NotBlank(message = "휴대폰 번호는 빈 값을 허용 하지 않습니다.")
     private String phoneNumber;
 
     public UserSignUpRequest() {

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/user/User.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/user/User.java
@@ -1,9 +1,6 @@
 package grepp.NBE5_6_2_Team03.domain.user;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,6 +15,8 @@ public class User {
     private String password;
     private String name;
     private String phoneNumber;
+
+    @Enumerated(EnumType.STRING)
     private Role role;
 
     protected User() {

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/user/service/UserService.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/user/service/UserService.java
@@ -1,9 +1,9 @@
-package grepp.NBE5_6_2_Team03.api.controller.user.service;
+package grepp.NBE5_6_2_Team03.domain.user.service;
 
 import grepp.NBE5_6_2_Team03.api.controller.user.dto.request.UserSignUpRequest;
 import grepp.NBE5_6_2_Team03.domain.user.User;
 import grepp.NBE5_6_2_Team03.domain.user.repository.UserRepository;
-import grepp.NBE5_6_2_Team03.global.exception.DuplicatedException;
+import grepp.NBE5_6_2_Team03.global.exception.UserSignUpException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -38,7 +38,7 @@ public class UserService {
     private void duplicatedEmailCheck(User user) {
         userRepository.findByEmail(user.getEmail())
                 .ifPresent(findUser -> {
-                    throw new DuplicatedException(USER_EMAIL, USER_EMAIL_DUPLICATED);
+                    throw new UserSignUpException(USER_EMAIL, USER_EMAIL_DUPLICATED);
                 });
     }
 
@@ -46,7 +46,7 @@ public class UserService {
         userRepository.findByName(user.getName())
                 .ifPresent(
                         findUser -> {
-                            throw new DuplicatedException(USER_NAME, USER_NAME_DUPLICATED);
+                            throw new UserSignUpException(USER_NAME, USER_NAME_DUPLICATED);
                         }
                 );
     }

--- a/src/main/java/grepp/NBE5_6_2_Team03/global/advice/GlobalControllerAdvice.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/global/advice/GlobalControllerAdvice.java
@@ -1,0 +1,14 @@
+package grepp.NBE5_6_2_Team03.global.advice;
+
+import grepp.NBE5_6_2_Team03.global.exception.UserSignUpException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalControllerAdvice {
+
+    @ExceptionHandler(UserSignUpException.class)
+    public String userSignUpExceptionHandler(UserSignUpException e){
+        return "/user/signup-form";
+    }
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/global/exception/UserSignUpException.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/global/exception/UserSignUpException.java
@@ -1,9 +1,9 @@
 package grepp.NBE5_6_2_Team03.global.exception;
 
-public class DuplicatedException extends BusinessException{
+public class UserSignUpException extends BusinessException {
     private final Reason reason;
 
-    public DuplicatedException(Reason reason, Message message) {
+    public UserSignUpException(Reason reason, Message message) {
         super(message.getDescription());
         this.reason = reason;
     }

--- a/src/main/resources/templates/user/signup-form.html
+++ b/src/main/resources/templates/user/signup-form.html
@@ -100,11 +100,14 @@
         <p id="nameCheckResult" class="check-result"></p>
 
         <div class="single-input">
-            <input type="password" name="password" placeholder="비밀번호" required>
+            <input type="password" name="password" id="password" placeholder="비밀번호" required>
         </div>
+        <p id="passwordRuleMessage" class="check-result" style="text-align: left; font-size: 0.85rem;"></p>
+
         <div class="single-input">
-            <input type="tel" name="phone" placeholder="휴대폰 번호" required>
+            <input type="tel" name="phoneNumber" id="phone" placeholder="휴대폰 번호" required>
         </div>
+        <p id="phoneCheckResult" class="check-result" style="text-align: left; font-size: 0.85rem;"></p>
 
         <button type="submit" class="btn">회원가입</button>
     </form>
@@ -115,6 +118,7 @@
 </footer>
 
 <script>
+    // 이메일 중복 확인
     document.getElementById('checkEmailBtn').addEventListener('click', async () => {
         const email = document.getElementById('email').value;
 
@@ -141,6 +145,7 @@
         }
     });
 
+    // 이름 중복 확인
     document.getElementById('checkNameBtn').addEventListener('click', async () => {
         const name = document.getElementById('name').value;
 
@@ -164,6 +169,66 @@
         } catch (error) {
             console.error('이름 확인 중 오류 발생:', error);
             alert('이름 확인에 실패했습니다.');
+        }
+    });
+
+    // 비밀번호 유효성 검사
+    document.getElementById('password').addEventListener('input', (e) => {
+        const value = e.target.value;
+        const message = document.getElementById('passwordRuleMessage');
+        const specialCharCount = (value.match(/[!@#$%^&*()]/g) || []).length;
+
+        if (value.length >= 8 && value.length <= 15 && specialCharCount >= 2) {
+            message.textContent = '사용 가능한 비밀번호입니다.';
+            message.style.color = 'green';
+        } else {
+            message.textContent = '최소 8자 ~ 15자이며 특수문자를 2개 이상 포함';
+            message.style.color = 'red';
+        }
+    });
+
+    // 이름 유효성 검사
+    document.getElementById('name').addEventListener('input', () => {
+        const value = document.getElementById('name').value;
+        const resultElement = document.getElementById('nameCheckResult');
+        const nameRegex = /^[A-Za-z가-힣0-9]{2,10}$/;
+
+        if (nameRegex.test(value)) {
+            resultElement.textContent = '올바른 이름 형식입니다.';
+            resultElement.style.color = 'green';
+        } else {
+            resultElement.textContent = '한영 숫자 2자~10자 가능 합니다.';
+            resultElement.style.color = 'red';
+        }
+    });
+
+    // 이메일 형식 유효성 검사
+    document.getElementById('email').addEventListener('input', () => {
+        const value = document.getElementById('email').value;
+        const resultElement = document.getElementById('emailCheckResult');
+        const emailRegex = /^[A-Za-z0-9]+@[A-Za-z0-9]+\.com$/;
+
+        if (emailRegex.test(value)) {
+            resultElement.textContent = '올바른 이메일 형식입니다.';
+            resultElement.style.color = 'green';
+        } else {
+            resultElement.textContent = '올바른 이메일 형식이 아닙니다.';
+            resultElement.style.color = 'red';
+        }
+    });
+
+    // 휴대폰 번호 유효성 검사
+    document.getElementById('phone').addEventListener('input', () => {
+        const value = document.getElementById('phone').value;
+        const resultElement = document.getElementById('phoneCheckResult');
+        const phoneRegex = /^01[016789]-\d{3,4}-\d{4}$/;
+
+        if (phoneRegex.test(value)) {
+            resultElement.textContent = '올바른 휴대폰 번호 형식입니다.';
+            resultElement.style.color = 'green';
+        } else {
+            resultElement.textContent = '형식: 010-1234-5678';
+            resultElement.style.color = 'red';
         }
     });
 </script>

--- a/src/test/java/grepp/NBE5_6_2_Team03/api/controller/user/UserControllerTest.java
+++ b/src/test/java/grepp/NBE5_6_2_Team03/api/controller/user/UserControllerTest.java
@@ -2,7 +2,7 @@ package grepp.NBE5_6_2_Team03.api.controller.user;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import grepp.NBE5_6_2_Team03.api.controller.user.dto.request.UserSignUpRequest;
-import grepp.NBE5_6_2_Team03.api.controller.user.service.UserService;
+import grepp.NBE5_6_2_Team03.domain.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,7 +59,7 @@ class UserControllerTest {
         return UserSignUpRequest.builder()
                 .email(email)
                 .name(name)
-                .password("tempPassword")
+                .password("tempPassword!@")
                 .phoneNumber("010-1234-5678")
                 .build();
     }

--- a/src/test/java/grepp/NBE5_6_2_Team03/api/controller/user/service/UserServiceTest.java
+++ b/src/test/java/grepp/NBE5_6_2_Team03/api/controller/user/service/UserServiceTest.java
@@ -3,7 +3,8 @@ package grepp.NBE5_6_2_Team03.api.controller.user.service;
 import grepp.NBE5_6_2_Team03.api.controller.user.dto.request.UserSignUpRequest;
 import grepp.NBE5_6_2_Team03.domain.user.User;
 import grepp.NBE5_6_2_Team03.domain.user.repository.UserRepository;
-import grepp.NBE5_6_2_Team03.global.exception.DuplicatedException;
+import grepp.NBE5_6_2_Team03.domain.user.service.UserService;
+import grepp.NBE5_6_2_Team03.global.exception.UserSignUpException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +49,7 @@ class UserServiceTest {
 
         //when //then
         assertThatThrownBy(() -> userService.signup(request))
-                .isInstanceOf(DuplicatedException.class)
+                .isInstanceOf(UserSignUpException.class)
                 .hasMessage("회원 이메일이 이미 사용중 입니다.");
     }
 
@@ -64,7 +65,7 @@ class UserServiceTest {
 
         //when //then
         assertThatThrownBy(() -> userService.signup(request))
-                .isInstanceOf(DuplicatedException.class)
+                .isInstanceOf(UserSignUpException.class)
                 .hasMessage("회원 이름이 이미 사용중 입니다.");
     }
 


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
### [ 회원 가입 검증 로직 추가 ]
- 이메일 : 이메일 형식 체크
- 비밀번호 : 8자 이상 ~ 15자 이하 , 특수문자 2개 포함
- 닉네임 : 2자 이상 ~ 10자리 이하
- 휴대폰 번호 : ex) 010-1234-5678

---
### [ 중복 예외를 회원 가입 예외로 변경 ]
- 중복 예외는 공통 예외라 핸들러 처리가 어렵습니다.
- 중복 예외를 회원 가입 예외로 변경
- 회원가입 예외 발생시 회원 가입 폼으로 이동
- 공통 advice 생성 후 회원 가입 예외 핸들러 등록

---
## 🌱 화면
### [ 성공 ]
![image](https://github.com/user-attachments/assets/f649f9d8-91df-4aea-8e71-d1c395de3e7d)
---
### [ 실패 ]
![image](https://github.com/user-attachments/assets/df21f839-df46-423a-9536-fed7942fdef9)


## ✅ 고친 부분 ( Fix )
- 회원 Role : 저장 타입 Ordinary ( 순서 ) To String 

