### PR TITLE
feat: 정산 기능 ( 미완성 ) 및 양방향 연관관계 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	// h2
+	testImplementation 'com.h2database:h2'
 }
 
 clean {

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/travelplan/TravelPlanController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/travelplan/TravelPlanController.java
@@ -1,6 +1,6 @@
 package grepp.NBE5_6_2_Team03.api.controller.travelplan;
 
-import grepp.NBE5_6_2_Team03.api.controller.travelplan.dto.TravelPlanRequestDto;
+import grepp.NBE5_6_2_Team03.api.controller.travelplan.dto.request.TravelPlanRequestDto;
 import grepp.NBE5_6_2_Team03.domain.travelplan.TravelPlan;
 import grepp.NBE5_6_2_Team03.domain.travelplan.service.TravelPlanService;
 import grepp.NBE5_6_2_Team03.domain.user.CustomUserDetails;

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/travelplan/dto/request/TravelPlanRequestDto.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/travelplan/dto/request/TravelPlanRequestDto.java
@@ -1,4 +1,4 @@
-package grepp.NBE5_6_2_Team03.api.controller.travelplan.dto;
+package grepp.NBE5_6_2_Team03.api.controller.travelplan.dto.request;
 
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/travelplan/dto/response/TravelPlanAdjustResponse.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/travelplan/dto/response/TravelPlanAdjustResponse.java
@@ -1,0 +1,44 @@
+package grepp.NBE5_6_2_Team03.api.controller.travelplan.dto.response;
+
+import grepp.NBE5_6_2_Team03.domain.travelplan.TravelPlan;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class TravelPlanAdjustResponse {
+
+    private List<TravelScheduleExpenseInfo> expenses;
+    private String country;
+    private int publicMoney;
+    private int count;
+    private int totalPrice;
+    private int remainMoney;
+    private int personalPrice;
+
+    @Builder
+    private TravelPlanAdjustResponse(List<TravelScheduleExpenseInfo> expenses, String country, int publicMoney,
+                                    int count, int totalPrice, int personalPrice, int remainMoney) {
+        this.expenses = expenses;
+        this.country = country;
+        this.publicMoney = publicMoney;
+        this.count = count;
+        this.totalPrice = totalPrice;
+        this.personalPrice = personalPrice;
+        this.remainMoney = remainMoney;
+    }
+
+    public static TravelPlanAdjustResponse of(List<TravelScheduleExpenseInfo> expenseInfos, TravelPlan travelPlan,
+                                              int totalPrice, int remainMoney, int personalPrice) {
+        return TravelPlanAdjustResponse.builder()
+                .expenses(expenseInfos)
+                .country(travelPlan.getCountry())
+                .publicMoney(travelPlan.getPublicMoney())
+                .count(travelPlan.getCount())
+                .totalPrice(totalPrice)
+                .personalPrice(personalPrice)
+                .remainMoney(remainMoney)
+                .build();
+    }
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/travelplan/dto/response/TravelScheduleExpenseInfo.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/travelplan/dto/response/TravelScheduleExpenseInfo.java
@@ -1,0 +1,45 @@
+package grepp.NBE5_6_2_Team03.api.controller.travelplan.dto.response;
+
+import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelRoute;
+import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelSchedule;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class TravelScheduleExpenseInfo {
+
+    private String placeName;
+    private String content;
+    private TravelRoute travelRoute;
+    private int payedPrice;
+
+    @Builder
+    private TravelScheduleExpenseInfo(String placeName, String content, TravelRoute travelRoute, int payedPrice) {
+        this.placeName = placeName;
+        this.content = content;
+        this.travelRoute = travelRoute;
+        this.payedPrice = payedPrice;
+    }
+
+    public static List<TravelScheduleExpenseInfo> convertBy(List<TravelSchedule> travelSchedules) {
+       return travelSchedules.stream()
+                .map(travelSchedule -> TravelScheduleExpenseInfo.of(
+                        travelSchedule.getTravelRoute(),
+                        travelSchedule.getContent(),
+                        travelSchedule.getPlaceName(),
+                        travelSchedule.getExpense().getPayedPrice()
+                ))
+               .toList();
+    }
+
+    public static TravelScheduleExpenseInfo of(TravelRoute travelRoute, String content, String placeName, int payedPrice){
+        return TravelScheduleExpenseInfo.builder()
+                .travelRoute(travelRoute)
+                .content(content)
+                .placeName(placeName)
+                .payedPrice(payedPrice)
+                .build();
+    }
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/expense/Expense.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/expense/Expense.java
@@ -3,16 +3,13 @@ package grepp.NBE5_6_2_Team03.domain.expense;
 import grepp.NBE5_6_2_Team03.domain.BaseEntity;
 import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelSchedule;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 
-@Entity
 @Getter
-@Builder
-@AllArgsConstructor
+@Entity
 public class Expense extends BaseEntity {
 
     @Id
@@ -29,7 +26,18 @@ public class Expense extends BaseEntity {
     private boolean isCompleted;
     private LocalDate expenseDate;
 
-    protected Expense() {
+    protected Expense() {}
+
+    @Builder
+    private Expense(TravelSchedule travelSchedule, Integer expectPrice, Integer payedPrice,
+                    String currency, boolean isCompleted, LocalDate expenseDate) {
+        this.travelSchedule = travelSchedule;
+        this.expectPrice = expectPrice;
+        this.payedPrice = payedPrice;
+        this.currency = currency;
+        this.isCompleted = isCompleted;
+        this.expenseDate = expenseDate;
+        travelSchedule.setExpense(this);
     }
 
     public void edit(Integer expectPrice, Integer payedPrice) {

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/travelplan/TravelPlan.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/travelplan/TravelPlan.java
@@ -1,29 +1,20 @@
 package grepp.NBE5_6_2_Team03.domain.travelplan;
 
 import grepp.NBE5_6_2_Team03.domain.BaseEntity;
+import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelSchedule;
 import grepp.NBE5_6_2_Team03.domain.user.User;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.persistence.*;
 
-@Entity
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.*;
+
 @Getter
 @Setter
 @Table(name = "travel_plan")
-@Builder @AllArgsConstructor
+@Entity
 public class TravelPlan extends BaseEntity {
 
     @Id
@@ -34,8 +25,11 @@ public class TravelPlan extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @OneToMany(mappedBy = "travelPlan")
+    private List<TravelSchedule> travelSchedules = new ArrayList<>();
+
     @Enumerated(EnumType.STRING)
-    CountryStatus countryStatus;
+    private CountryStatus countryStatus;
 
     private String country;
     private String name;
@@ -45,8 +39,19 @@ public class TravelPlan extends BaseEntity {
     private LocalDate travelStartDate;
     private LocalDate travelEndDate;
 
-    private LocalDateTime createdDateTime;
-    private LocalDateTime modifyDateTime;
-
     protected TravelPlan() {}
+
+    @Builder
+    private TravelPlan(User user, CountryStatus countryStatus, String country, String name,
+                      int publicMoney, int count, LocalDate travelStartDate, LocalDate travelEndDate) {
+        this.user = user;
+        this.countryStatus = countryStatus;
+        this.country = country;
+        this.name = name;
+        this.publicMoney = publicMoney;
+        this.count = count;
+        this.travelStartDate = travelStartDate;
+        this.travelEndDate = travelEndDate;
+    }
+
 }

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/travelplan/repository/TravelPlanQueryRepository.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/travelplan/repository/TravelPlanQueryRepository.java
@@ -1,0 +1,31 @@
+package grepp.NBE5_6_2_Team03.domain.travelplan.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import grepp.NBE5_6_2_Team03.domain.travelplan.TravelPlan;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import static grepp.NBE5_6_2_Team03.domain.expense.QExpense.*;
+import static grepp.NBE5_6_2_Team03.domain.travelplan.QTravelPlan.*;
+import static grepp.NBE5_6_2_Team03.domain.travelschedule.QTravelSchedule.*;
+
+@Repository
+public class TravelPlanQueryRepository {
+
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+    public TravelPlanQueryRepository(EntityManager em) {
+        this.em = em;
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    public TravelPlan getTravelPlanFetchScheduleAndExpense(Long travelPlanId){
+        return queryFactory.selectDistinct(travelPlan)
+                .from(travelPlan)
+                .leftJoin(travelPlan.travelSchedules, travelSchedule).fetchJoin()
+                .leftJoin(travelSchedule.expense, expense).fetchJoin()
+                .where(travelPlan.travelPlanId.eq(travelPlanId))
+                .fetchOne();
+    }
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/travelplan/service/TravelPlanQueryService.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/travelplan/service/TravelPlanQueryService.java
@@ -1,0 +1,57 @@
+package grepp.NBE5_6_2_Team03.domain.travelplan.service;
+
+import grepp.NBE5_6_2_Team03.api.controller.travelplan.dto.response.TravelPlanAdjustResponse;
+import grepp.NBE5_6_2_Team03.api.controller.travelplan.dto.response.TravelScheduleExpenseInfo;
+import grepp.NBE5_6_2_Team03.domain.expense.Expense;
+import grepp.NBE5_6_2_Team03.domain.travelplan.TravelPlan;
+import grepp.NBE5_6_2_Team03.domain.travelplan.repository.TravelPlanQueryRepository;
+import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelSchedule;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+@Transactional(readOnly = true)
+@Service
+public class TravelPlanQueryService {
+
+    private final TravelPlanQueryRepository planQueryRepository;
+
+    public TravelPlanQueryService(TravelPlanQueryRepository planQueryRepository) {
+        this.planQueryRepository = planQueryRepository;
+    }
+
+    public TravelPlanAdjustResponse getAdjustmentInfo(Long travelPlanId){
+        TravelPlan travelPlan = planQueryRepository.getTravelPlanFetchScheduleAndExpense(travelPlanId);
+        List<TravelSchedule> travelSchedules = travelPlan.getTravelSchedules();
+        List<Expense> expenses = findNotNullExpense(travelSchedules);
+
+        int remainMoney = getRemainMoney(travelPlan.getPublicMoney(), expenses);
+        int personalPrice = getPersonalPrice(remainMoney, travelPlan.getCount());
+
+        List<TravelScheduleExpenseInfo> expenseInfos = TravelScheduleExpenseInfo.convertBy(travelSchedules);
+        return TravelPlanAdjustResponse.of(expenseInfos, travelPlan, getTotalExpenses(expenses), personalPrice, remainMoney);
+    }
+
+    private List<Expense> findNotNullExpense(List<TravelSchedule> travelSchedules) {
+        return travelSchedules.stream()
+                .map(TravelSchedule::getExpense)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private int getRemainMoney(int publicMoney, List<Expense> expenses) {
+        return publicMoney - getTotalExpenses(expenses);
+    }
+
+    private int getTotalExpenses(List<Expense> expenses) {
+        return expenses.stream()
+                .mapToInt(Expense::getPayedPrice)
+                .sum();
+    }
+
+    private int getPersonalPrice(int remainMoney, int count) {
+        return remainMoney / count;
+    }
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/travelplan/service/TravelPlanService.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/travelplan/service/TravelPlanService.java
@@ -1,13 +1,12 @@
 package grepp.NBE5_6_2_Team03.domain.travelplan.service;
 
-import grepp.NBE5_6_2_Team03.api.controller.travelplan.dto.TravelPlanRequestDto;
+import grepp.NBE5_6_2_Team03.api.controller.travelplan.dto.request.TravelPlanRequestDto;
 import grepp.NBE5_6_2_Team03.domain.travelplan.CountryStatus;
 import grepp.NBE5_6_2_Team03.domain.travelplan.TravelPlan;
 import grepp.NBE5_6_2_Team03.domain.travelplan.repository.TravelPlanRepository;
 import grepp.NBE5_6_2_Team03.domain.user.User;
 import grepp.NBE5_6_2_Team03.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,8 +40,6 @@ public class TravelPlanService {
             .count(planDto.getCount())
             .travelStartDate(planDto.getTravelStartDate())
             .travelEndDate(planDto.getTravelEndDate())
-            .createdDateTime(LocalDateTime.now())
-            .modifyDateTime(LocalDateTime.now())
             .build();
 
         travelPlanRepository.save(plan);
@@ -76,7 +73,6 @@ public class TravelPlanService {
         existingPlan.setCount(planDto.getCount());
         existingPlan.setTravelStartDate(planDto.getTravelStartDate());
         existingPlan.setTravelEndDate(planDto.getTravelEndDate());
-        existingPlan.setModifyDateTime(LocalDateTime.now());
 
         travelPlanRepository.save(existingPlan);
     }

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/travelschedule/TravelSchedule.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/travelschedule/TravelSchedule.java
@@ -1,17 +1,16 @@
 package grepp.NBE5_6_2_Team03.domain.travelschedule;
 
 import grepp.NBE5_6_2_Team03.domain.BaseEntity;
+import grepp.NBE5_6_2_Team03.domain.expense.Expense;
 import grepp.NBE5_6_2_Team03.domain.travelplan.TravelPlan;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
 
-@Entity
+@Setter
 @Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Entity
 public class TravelSchedule extends BaseEntity {
 
     @Id
@@ -22,6 +21,9 @@ public class TravelSchedule extends BaseEntity {
     @JoinColumn(name = "travel_plan_id")
     private TravelPlan travelPlan;
 
+    @OneToOne(mappedBy = "travelSchedule", fetch = FetchType.LAZY)
+    private Expense expense;
+
     @Embedded
     private TravelRoute travelRoute;
 
@@ -31,6 +33,20 @@ public class TravelSchedule extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ScheduleStatus scheduleStatus;
     private LocalDate travelScheduleDate;
+
+    protected TravelSchedule() {}
+
+    @Builder
+    private TravelSchedule(TravelPlan travelPlan, TravelRoute travelRoute, String content,
+                           String placeName, ScheduleStatus scheduleStatus, LocalDate travelScheduleDate) {
+        this.travelPlan = travelPlan;
+        this.travelRoute = travelRoute;
+        this.content = content;
+        this.placeName = placeName;
+        this.scheduleStatus = scheduleStatus;
+        this.travelScheduleDate = travelScheduleDate;
+        travelPlan.getTravelSchedules().add(this);
+    }
 
     public void edit(TravelRoute travelRoute, String content, String placeName, LocalDate travelScheduleDate) {
         this.travelRoute = travelRoute;

--- a/src/test/java/grepp/NBE5_6_2_Team03/domain/travelplan/repository/TravelPlanQueryRepositoryTest.java
+++ b/src/test/java/grepp/NBE5_6_2_Team03/domain/travelplan/repository/TravelPlanQueryRepositoryTest.java
@@ -1,0 +1,97 @@
+package grepp.NBE5_6_2_Team03.domain.travelplan.repository;
+
+import grepp.NBE5_6_2_Team03.domain.expense.Expense;
+import grepp.NBE5_6_2_Team03.domain.expense.repository.ExpenseRepository;
+import grepp.NBE5_6_2_Team03.domain.travelplan.TravelPlan;
+import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelRoute;
+import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelSchedule;
+import grepp.NBE5_6_2_Team03.domain.travelschedule.repository.TravelScheduleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest
+class TravelPlanQueryRepositoryTest {
+
+    @Autowired
+    private TravelPlanRepository travelPlanRepository;
+
+    @Autowired
+    private TravelPlanQueryRepository travelPlanQueryRepository;
+
+    @Autowired
+    private TravelScheduleRepository travelScheduleRepository;
+
+    @Autowired
+    private ExpenseRepository expenseRepository;
+
+    @DisplayName("여행 계획과 연관된 일정, 지출을 조회 한다.")
+    @Test
+    void getTravelPlanFetchScheduleAndExpense() {
+        //given
+        TravelPlan travelPlan = createTravelPlan("일본", "여행 계획", 10000, 2);
+        travelPlanRepository.save(travelPlan);
+
+        TravelRoute travelRoute = createTravelRoute();
+        TravelSchedule travelSchedule = createTravelSchedule(travelPlan, travelRoute, "일정 내용1", "장소 이름1");
+        TravelSchedule travelSchedule2 = createTravelSchedule(travelPlan, travelRoute, "일정 내용2", "장소 이름2");
+        TravelSchedule travelSchedule3 = createTravelSchedule(travelPlan, travelRoute, "일정 내용3", "장소 이름3");
+        travelScheduleRepository.saveAll(List.of(travelSchedule, travelSchedule2, travelSchedule3));
+
+        Expense expense = createExpense(travelSchedule, 1000);
+        Expense expense2 = createExpense(travelSchedule2, 2000);
+        expenseRepository.saveAll(List.of(expense, expense2));
+
+        //when
+        TravelPlan findTravelPlan = travelPlanQueryRepository.getTravelPlanFetchScheduleAndExpense(travelPlan.getTravelPlanId());
+
+        //then
+        assertThat(findTravelPlan).isNotNull();
+
+        List<TravelSchedule> travelSchedules = findTravelPlan.getTravelSchedules();
+        assertThat(travelSchedules).hasSize(3);
+        assertThat(travelSchedules)
+                .extracting(TravelSchedule::getExpense)
+                .filteredOn(Objects::nonNull)
+                .hasSize(2);
+    }
+
+    private TravelRoute createTravelRoute() {
+        return new TravelRoute("출발지", "목적지", "이동수단");
+    }
+
+    private TravelPlan createTravelPlan(String country, String name, int publicMoney, int count){
+        return TravelPlan.builder()
+                .country(country)
+                .name(name)
+                .publicMoney(publicMoney)
+                .count(count)
+                .build();
+    }
+
+    private TravelSchedule createTravelSchedule(TravelPlan travelPlan, TravelRoute travelRoute, String content, String placeName){
+       return TravelSchedule.builder()
+                .travelPlan(travelPlan)
+                .travelRoute(travelRoute)
+                .content(content)
+                .placeName(placeName)
+                .build();
+    }
+
+    private Expense createExpense(TravelSchedule travelSchedule, int payedPrice){
+        return Expense.builder()
+                .travelSchedule(travelSchedule)
+                .payedPrice(payedPrice)
+                .build();
+    }
+}


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
### [ 정산 기능 추가 ( 미완성 ) ]
- 정산 기본 로직 작성 
- 여행 계획, 일정, 지출 내역 조회 쿼리 테스트

---
### [ 여행 계획 및 여행 일정 양방향 연관 관계 추가 ]
- 여행 계획 - 여행일정 ( OneToMany ) 추가
- 여행 일정 - 지출 ( OneToOne ) 추가

---
## ✅ 기타 사항
- 테스트 H2 데이터베이스 추가
- 여행 계획 request, response 폴더 분리