### PR TITLE
fix: 회원 삭제 기능 오류 수정

### DIFF
--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/travelplan/repository/TravelPlanRepository.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/travelplan/repository/TravelPlanRepository.java
@@ -17,4 +17,5 @@ public interface TravelPlanRepository extends JpaRepository<TravelPlan, Long> {
         + "group by month(t.travel_start_date) order by month(t.travel_start_date)", nativeQuery = true)
     List<Object[]> getMonthStatistics();
 
+    long deleteByUserId(Long userId);
 }

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/user/service/UserService.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package grepp.NBE5_6_2_Team03.domain.user.service;
 import grepp.NBE5_6_2_Team03.api.controller.user.dto.request.UserEditRequest;
 import grepp.NBE5_6_2_Team03.api.controller.user.dto.request.UserSignUpRequest;
 import grepp.NBE5_6_2_Team03.api.controller.user.dto.response.UserMyPageResponse;
+import grepp.NBE5_6_2_Team03.domain.travelplan.repository.TravelPlanRepository;
 import grepp.NBE5_6_2_Team03.domain.user.User;
 import grepp.NBE5_6_2_Team03.domain.user.exception.InvalidPasswordException;
 import grepp.NBE5_6_2_Team03.domain.user.file.FileStore;
@@ -27,6 +28,7 @@ import static grepp.NBE5_6_2_Team03.global.exception.Reason.*;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final TravelPlanRepository travelPlanRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final FileStore fileStore;
     private final SecurityContextUpdater securityContextUpdater;
@@ -67,6 +69,7 @@ public class UserService {
 
     @Transactional
     public void deleteUserBy(Long userId) {
+        travelPlanRepository.deleteByUserId(userId);
         userRepository.deleteById(userId);
     }
 


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용 
### [ 회원 삭제 오류 수정 ] 
- 문제 : 여행 계획이 회원id를 외래키를 가지고 있어 삭제시 참조 무결성 문제 발생
---
### [ 해결 방안 ] 
- 회원 삭제시 연관된 여행계획 삭제후 제거
